### PR TITLE
Relative API Calls (#62)

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -98,7 +98,7 @@ module.exports = function (grunt) {
                 NODE_ENV: "local",
                 //BW_DATA_URL: "https://dss-aws-staging.ucsc-cgp-dev.org"
                // BW_DATA_URL: "https://carlos.ucsc-cgp-dev.org"
-                BW_DATA_URL: "https://ucsc-cgp.org"
+                //BW_DATA_URL: "https://ucsc-cgp.org"
             }
         },
 

--- a/README.md
+++ b/README.md
@@ -57,9 +57,11 @@ The URL for the back end Azul Facet Service is configurable from the environment
 
 If this value is not set, the Boardwalk Angular client will assume the Facet Server is at the same url that served the front end, and make a relative request to /api/v1 to retrieve the facets and other configuration. 
 
-To support this, on localhost, run the proxy.json file with `node proxy.json` This will start a proxy server at port 3001. ```proxy.conf.json``` in ```/spa``` is configured to forward requests to /api to the local node.js server at port 3000 and to send /api/v1 to requests to the proxy listening at port 3001.
+To support this, on localhost, we run the proxy.js file with `node proxy.js` This will start a proxy server at port 3001. 
 
-The HTTP-Proxy on port 3001 is configured to send all requests to https://commons.ucsc-cgp-dev.org but this can be chaned as required.
+Angular is configured using```proxy.conf.json``` in ```/spa``` to forward requests to /api to the local node.js server at port 3000 and to send /api/v1 to requests to the proxy listening at port 3001. The HTTP-Proxy on port 3001 is configured to send all requests to https://commons.ucsc-cgp-dev.org but this can be chaned as required.
+
+```npm start``` in the /spa directory will launch the http-proxy for you and also start the local Angular dev server.
 
 
 ``````

--- a/README.md
+++ b/README.md
@@ -1,12 +1,5 @@
 # UCSC Boardwalk
 
-UCSC Boardwalk is a MEAN stack app and uses standard setup/configuration tools (NPM and Grunt).
-
-See the following for more details:
-
-- [http://mean.io](http://mean.io)
-- [https://www.npmjs.org](https://www.npmjs.org)
-- [http://gruntjs.com](http://gruntjs.com)
 
 ## Prerequisites
 UCSC Boardwalk is an [Angular 2 app](http://angular.io), built with the [Angular CLI tool](https://github.com/angular/angular-cli).
@@ -57,17 +50,26 @@ To start Express, run the following from the root directory:
 
 This will run the express server on `http://localhost:3000`
 
-## Run Client-Side Tests
+### 6. Local HTTP-Proxy to Facet Service
 
-Run the following from the `spa` directory:
 
-	npm test
-	
-This will run once through test-suite using PhantomJS. To run through PhantomJS with a file watcher, you can use:
+The URL for the back end Azul Facet Service is configurable from the environment property ```BW_DATA_URL```. This can be set to the url of the server running the back end in the Gruntfile to run locally or on the boardwalk node.js server.
 
-    npm test:headless
+If this value is not set, the Boardwalk Angular client will assume the Facet Server is at the same url that served the front end, and make a relative request to /api/v1 to retrieve the facets and other configuration. 
 
-To run the tests through the browser with a file watcher:
+To support this, on localhost, run the proxy.json file with `node proxy.json` This will start a proxy server at port 3001. ```proxy.conf.json``` in ```/spa``` is configured to forward requests to /api to the local node.js server at port 3000 and to send /api/v1 to requests to the proxy listening at port 3001.
 
-    npm test:browser
+The HTTP-Proxy on port 3001 is configured to send all requests to https://ucsc-cgp.org but this can be chaned as required.
 
+
+``````
+//
+// Create a HTTP Proxy server with a HTTPS target
+//
+httpProxy.createProxyServer({
+    target: 'https://ucsc-cgp.org',
+    agent  : https.globalAgent,
+    headers: {
+        host: 'ucsc-cgp.org'
+    }
+}).listen(3001);

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ If this value is not set, the Boardwalk Angular client will assume the Facet Ser
 
 To support this, on localhost, run the proxy.json file with `node proxy.json` This will start a proxy server at port 3001. ```proxy.conf.json``` in ```/spa``` is configured to forward requests to /api to the local node.js server at port 3000 and to send /api/v1 to requests to the proxy listening at port 3001.
 
-The HTTP-Proxy on port 3001 is configured to send all requests to https://ucsc-cgp.org but this can be chaned as required.
+The HTTP-Proxy on port 3001 is configured to send all requests to https://commons.ucsc-cgp-dev.org but this can be chaned as required.
 
 
 ``````

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "grunt-mocha-test": "^0.13.2",
     "grunt-spawn": "^1.1.74",
     "grunt-tslint": "5.0.1",
+    "http-proxy": "^1.17.0",
     "load-grunt-tasks": "^3.5.2",
     "mocha": "^3.1.2",
     "time-grunt": "^1.4.0",

--- a/proxy.js
+++ b/proxy.js
@@ -1,0 +1,35 @@
+
+
+var https = require('https'),
+    http  = require('http'),
+    util  = require('util'),
+    path  = require('path'),
+    fs    = require('fs'),
+    colors = require('colors'),
+    httpProxy = require('http-proxy');
+
+
+var welcome = [
+    '#    # ##### ##### #####        #####  #####   ####  #    # #   #',
+    '#    #   #     #   #    #       #    # #    # #    #  #  #   # # ',
+    '######   #     #   #    # ##### #    # #    # #    #   ##     #  ',
+    '#    #   #     #   #####        #####  #####  #    #   ##     #  ',
+    '#    #   #     #   #            #      #   #  #    #  #  #    #  ',
+    '#    #   #     #   #            #      #    #  ####  #    #   #  '
+].join('\n');
+
+console.log(welcome.rainbow.bold);
+
+
+//
+// Create a HTTP Proxy server with a HTTPS target
+//
+httpProxy.createProxyServer({
+    target: 'https://ucsc-cgp.org',
+    agent  : https.globalAgent,
+    headers: {
+        host: 'ucsc-cgp.org'
+    }
+}).listen(3001);
+
+console.log('http proxy server'.blue + ' started '.green.bold + 'on port '.blue + '3001'.yellow);

--- a/proxy.js
+++ b/proxy.js
@@ -25,10 +25,10 @@ console.log(welcome.rainbow.bold);
 // Create a HTTP Proxy server with a HTTPS target
 //
 httpProxy.createProxyServer({
-    target: 'https://ucsc-cgp.org',
+    target: 'https://commons.ucsc-cgp-dev.org',
     agent  : https.globalAgent,
     headers: {
-        host: 'ucsc-cgp.org'
+        host: 'commons.ucsc-cgp-dev.org'
     }
 }).listen(3001);
 

--- a/server/src/lib/config/config-webcontroller.ts
+++ b/server/src/lib/config/config-webcontroller.ts
@@ -23,6 +23,6 @@ import { Response } from "~express/lib/express";
 export function getConfig(req: Req, res: Res): Response {
 
     return setupResponseCallback(res)(null, {
-        dataURL: process.env.BW_DATA_URL || "https://carlos.ucsc-cgp-dev.org"
+        dataURL: process.env.BW_DATA_URL || ""
     } as ConfigViewModel);
 }

--- a/spa/package.json
+++ b/spa/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "scripts": {
     "ng": "ng",
-    "start": "ng serve -v --proxy-config proxy.conf.json",
+    "start": "node ../proxy.js &  ng serve -v --proxy-config proxy.conf.json",
     "build": "ng build --prod -aot false -op ../dist",
     "test": "ng test",
     "lint": "ng lint",

--- a/spa/proxy.conf.json
+++ b/spa/proxy.conf.json
@@ -1,6 +1,13 @@
 {
+
+  "/api/v1": {
+    "target": "http://localhost:3001",
+    "secure": false,
+    "debug":true
+  },
   "/api": {
     "target": "http://localhost:3000",
     "secure": false
+
   }
 }


### PR DESCRIPTION
@coverbeck I left the ability to specify the Azul Facet service via the BW_DATA_URL environment variable intact.  However, if this is not set, it now assumes a relative url to request the facets and other config.

To support running like this locally, I modified the Angular proxy and added a 2nd HTTP-Proxy. Basically any relative calls to /api/v1 will be forwarded by angular to port 3001. The HTTP-Proxy server running on 3001 will then forward to `https://ucsc-cgp.org`. The url can be changed in proxy.js

Let me know if you want to discuss. 

Cheers,
D