### PR TITLE
Bring toolbar into sync with Dashboard

### DIFF
--- a/spa/src/app/shared/cgl-toolbar/cgl-toolbar.component.html
+++ b/spa/src/app/shared/cgl-toolbar/cgl-toolbar.component.html
@@ -9,16 +9,7 @@
                 <a href="{{rootUrl}}/index.html">Home</a>
             </cc-toolbar-nav-item>
             <cc-toolbar-nav-item class="active">
-                <a href="{{rootUrl}}/boardwalk.html">Boardwalk</a>
-            </cc-toolbar-nav-item>
-            <cc-toolbar-nav-item>
-                <a href="https://ucsc-cgl.atlassian.net/wiki/" target="_blank">Wiki</a>
-            </cc-toolbar-nav-item>
-            <cc-toolbar-nav-item>
-                <a href="{{rootUrl}}/about.html">About</a>
-            </cc-toolbar-nav-item>
-            <cc-toolbar-nav-item>
-                <a href="{{rootUrl}}/help.html">Help</a>
+                <a href="{{rootUrl}}/boardwalk.html">Data Browser</a>
             </cc-toolbar-nav-item>
             <cc-toolbar-nav-item *ngIf="(authorizedUser$ | async) as user">
                 <a href="{{rootUrl}}/logout"><img src="{{user.avatar}}" alt="{{user.name}}" height="20" width="20">Logout</a>


### PR DESCRIPTION
Toolbar was shortened in Dashboard in DataBiosphere/cgp-dashboard#60;
this brings it into sync.