### PR TITLE
Call /me endpoint (fixes #63)

### DIFF
--- a/spa/src/app/auth/_ngrx/auth.selectors.ts
+++ b/spa/src/app/auth/_ngrx/auth.selectors.ts
@@ -26,4 +26,4 @@ export const selectAuthenticatedUser = createSelector(selectAuth, (state: AuthSt
  *
  * @type {MemoizedSelector<Object, string>}
  */
-export const selectRedwoodToken = createSelector(selectAuthenticatedUser, (user: User) => user.redwood_token);
+export const selectRedwoodToken = createSelector(selectAuthenticatedUser, (user: User) => null);

--- a/spa/src/app/data/user/user.model.ts
+++ b/spa/src/app/data/user/user.model.ts
@@ -1,6 +1,5 @@
 export interface User {
-    avatar: string;
-    email: string;
+    avatar?: string;
+    email?: string;
     name: string;
-    redwood_token: string;
 }

--- a/spa/src/app/data/user/user.service.ts
+++ b/spa/src/app/data/user/user.service.ts
@@ -17,7 +17,7 @@ export class UserService extends CCBaseDAO {
      * @returns {Observable<User>}
      */
     syncSession(): Observable<User> {
-        return this.get(`/api/session`);
+        return this.get(`/me`);
     }
 
     /**

--- a/spa/src/app/shared/cgl-toolbar/cgl-toolbar.component.ts
+++ b/spa/src/app/shared/cgl-toolbar/cgl-toolbar.component.ts
@@ -48,7 +48,7 @@ export class CGLToolbarComponent {
         });
 
         this.hasRedwoodToken$ = this.authorizedUser$.map((user: User) => {
-            return user && user.redwood_token !== "None";
+            return false;
         });
 
         this.rootUrl = this.configService.getDataURL();


### PR DESCRIPTION
Quickish fix to invoke /me endpoint, but wanted to get a version
we can deploy that will mainly work.

* redwood_token does not exist in Commons, so removed it from
User interface and tweaked code that referenced it.
* If you are not logged in, /me returns name only, so made avatar
and email optional in User interface.

To clean up, should remove redwood token references.

Also, I don't think we need to be be polling the /me endpoint, and
instead rely on #69 to handle the case where the user logs out.